### PR TITLE
support for customUrl; DreamHost out of the box; generic domain on feed.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Put the source under, say, `/var/www/html/ytpodcasts` and put the following into
 </Macro>
 
 Use force_https ytpodcasts.domain.com
-Use generic_wsgi passenger_wsgi.py ytpodcasts.domain.com ytpodcasts.domain.com
+Use generic_wsgi /var/www/html/ytpodcasts/passenger_wsgi.py ytpodcasts.domain.com ytpodcasts.domain.com
 
 UndefMacro force_https
 UndefMacro generic_wsgi

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This tool can convert any YouTube channel or a playlist into a downloadable podc
 - `https://m.youtube.com/user/latenight`
 - `https://www.youtube.com/channel/UCVTyTA7-g9nopHeHbeuvpRA`
 - `https://www.youtube.com/playlist?list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb`
+- `https://www.youtube.com/c/NotJustBikes`
 
 2. Open up your podcasts app and add a new podcast by URL. Copy and paste in the URL from step 1, except change the domain to youtube-podcast's one.
    Your modified URL should look like one of these:
@@ -34,12 +35,14 @@ This tool can convert any YouTube channel or a playlist into a downloadable podc
 - `https://podcast.becauseofprog.fr/user/latenight`
 - `https://podcast.becauseofprog.fr/channel/UCVTyTA7-g9nopHeHbeuvpRA`
 - `https://podcast.becauseofprog.fr/playlist?list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb`
+- `https://podcast.becauseofprog.fr/c/NotJustBikes`
 
 3. youtube-podcast generates video podcasts by default. If you'd like an audio-only podcast instead, simply add `?a` to the end of the URL for users or channels, or add `&a` to the end of the URL for playlists:
 
 - `https://podcast.becauseofprog.fr/user/latenight?a`
 - `https://podcast.becauseofprog.fr/channel/UCVTyTA7-g9nopHeHbeuvpRA?a`
 - `https://podcast.becauseofprog.fr/playlist?list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&a`
+- `https://podcast.becauseofprog.fr/c/NotJustBikes?a`
 
 4. Hit subscribe. You're all set. You can now download and refresh episodes, just like with any other podcast.
 
@@ -51,7 +54,7 @@ If you don't want to use the online version, you can install youtube-podcast on 
 
 ### Steps
 
-- Clone the repository : `git clone https://github.com/BecauseOfProg/yt-podcast.git`
+- Clone the repository : `git clone https://github.com/avibrazil/yt-podcast.git`
 - Install requirements : `pip3 install -r requirements.txt`
 - You'll need a [YouTube API key](https://stackoverflow.com/questions/44399219/where-to-find-the-youtube-api-key), put it in a new file named `g.py` in /epi/ like this : `KEY = 'R4nd0mAp1k3y'`
 - You must also add the domain or url for your yt-podcast instance in g.py : `DOMAIN = 'domain.tld'`

--- a/passenger_wsgi.py
+++ b/passenger_wsgi.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python3
+
+# Required to make it run on DreamHost
+
+import os
+import sys
+
+INTERP = "/usr/bin/python3"
+if sys.executable != INTERP: os.execl(INTERP, INTERP, *sys.argv)
+
+sys.path.append(os.getcwd())
+
+import views.channel
+import views.download
+import views.index
+
+from app import app as application

--- a/passenger_wsgi.py
+++ b/passenger_wsgi.py
@@ -8,7 +8,7 @@ import sys
 INTERP = "/usr/bin/python3"
 if sys.executable != INTERP: os.execl(INTERP, INTERP, *sys.argv)
 
-sys.path.append(os.getcwd())
+sys.path.append(os.path.dirname(__file__))
 
 import views.channel
 import views.download

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flask>=1.0.2
 requests>=2.21.0
-youtube-dl>=2019.2.18
+yt-dlp
 isodate

--- a/templates/feed.xml
+++ b/templates/feed.xml
@@ -32,7 +32,7 @@
             <title>{{ item.snippet.title }}</title>
             <link>https://www.youtube.com/watch?v={{ item.id }}</link>
             <description>{{ item.snippet.description }}</description>
-            <enclosure url="https://podcast.becauseofprog.fr/download/{{ videos_data['podcast_type'] }}/{{ item.id }}.{{ videos_data['media_extension'] }}" type="{{ videos_data['podcast_type'] }}/{{ videos_data['media_extension'] }}"/>
+            <enclosure url="http://{{ DOMAIN }}/download/{{ videos_data['podcast_type'] }}/{{ item.id }}.{{ videos_data['media_extension'] }}" type="{{ videos_data['podcast_type'] }}/{{ videos_data['media_extension'] }}"/>
             <guid>https://www.youtube.com/watch?v={{ item.id }}</guid>
             <pubDate>{{ item.snippet.publishedAt }}</pubDate>
             <itunes:duration>{{ item.contentDetails.duration }}</itunes:duration>

--- a/templates/index.html
+++ b/templates/index.html
@@ -119,6 +119,7 @@
               <li><code>https://m.youtube.com/user/latenight</code></li>
               <li><code>https://www.youtube.com/channel/UCVTyTA7-g9nopHeHbeuvpRA</code></li>
               <li><code>https://www.youtube.com/playlist?list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb</code></li>
+              <li><code>https://www.youtube.com/c/NotJustBikes</code></li>
             </ul>
         </li>
         <li>
@@ -128,6 +129,7 @@
             <li><code>https://{{DOMAIN}}/user/latenight</code></li>
             <li><code>https://{{DOMAIN}}/channel/UCVTyTA7-g9nopHeHbeuvpRA</code></li>
             <li><code>https://{{DOMAIN}}/playlist?list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb</code></li>
+            <li><code>https://{{DOMAIN}}/c/NotJustBikes</code></li>
           </ul>
         </li>
         <li>
@@ -136,6 +138,7 @@
             <li><code>https://{{DOMAIN}}/user/latenight?a</code></li>
             <li><code>https://{{DOMAIN}}/channel/UCVTyTA7-g9nopHeHbeuvpRA?a</code></li>
             <li><code>https://{{DOMAIN}}/playlist?list=PLUl4u3cNGP61Oq3tWYp6V_F-5jb5L2iHb&amp;a</code></li>
+            <li><code>https://{{DOMAIN}}/c/NotJustBikes?a</code></li>
           </ul>
         </li>
           <li>
@@ -152,7 +155,7 @@
       
       <h3 id="steps-">Steps :</h3>
       <ul>
-        <li>Clone the repository : <code>git clone https://github.com/BecauseOfProg/yt-podcast.git</code></li>
+        <li>Clone the repository : <code>git clone https://github.com/avibrazil/yt-podcast.git</code></li>
         <li>Install requirements : <code>pip3 install -r requirements.txt</code></li>
         <li>You&#39;ll need a <a href="https://stackoverflow.com/questions/44399219/where-to-find-the-youtube-api-key">YouTube API key</a>, put it in a new file named <code>g.py</code> in /epi/ like this : <code>KEY = &#39;R4nd0mAp1k3y&#39;</code></li>
         <li>Use <code>python3 run.py</code>  to run youtube-dl</li>

--- a/utils/get_data.py
+++ b/utils/get_data.py
@@ -2,10 +2,25 @@ from utils.youtube_api_call import yt_api_call
 
 
 def get_channel_data(id_type, user):
-    '''Return a dictionary of channel data from a channel id or username.'''
+    '''Return a dictionary of channel data from a channel id, username or custom URL.'''
+    if id_type == 'custom':
+        guess_channel = yt_api_call(
+            path      = 'search',
+            part      = 'snippet',
+            id_type   = 'q',
+            id_value  = user
+        )
+
+        # Get first response and prepare classical route
+        user = guess_channel.items[0].id.channelId
+        id_type = 'channel'
+
     id_type = 'id' if id_type == 'channel' else 'forUsername'
+
     channel_data = yt_api_call(
-        'channels', 'contentDetails,snippet', id_type, user)
+        'channels', 'contentDetails,snippet', id_type, user
+    )
+
     return channel_data
 
 

--- a/utils/get_data.py
+++ b/utils/get_data.py
@@ -12,7 +12,7 @@ def get_channel_data(id_type, user):
             id_value  = user
         )
 
-        # Get only returned IDs
+        # Get only returned channel IDs
         cIDs = [item['id']['channelId'] for item in guess_channel['items']]
 
         # Get more details of all returned channels
@@ -26,7 +26,7 @@ def get_channel_data(id_type, user):
         # Search for exact customUrl match in all channel details and set user variable
         for item in guess_channel['items']:
             if "customUrl" in item['snippet']:
-                if user.casefold()==item['snippet']["customUrl"].casefold():
+                if ('@' + user).casefold()==item['snippet']["customUrl"].casefold():
                     user = item['id']
                     break
 

--- a/utils/get_data.py
+++ b/utils/get_data.py
@@ -4,6 +4,7 @@ from utils.youtube_api_call import yt_api_call
 def get_channel_data(id_type, user):
     '''Return a dictionary of channel data from a channel id, username or custom URL.'''
     if id_type == 'custom':
+        # Search channels that might have custom part of URL in the snippet
         guess_channel = yt_api_call(
             path      = 'search',
             part      = 'snippet',
@@ -11,8 +12,25 @@ def get_channel_data(id_type, user):
             id_value  = user
         )
 
-        # Get first response and prepare classical route
-        user = guess_channel.items[0].id.channelId
+        # Get only returned IDs
+        cIDs = [item['id']['channelId'] for item in guess_channel['items']]
+
+        # Get more details of all returned channels
+        guess_channel = yt_api_call(
+            path      = 'channels',
+            part      = 'snippet',
+            id_type   = 'id',
+            id_value  = ','.join(cIDs)
+        )
+
+        # Search for exact customUrl match in all channel details and set user variable
+        for item in guess_channel['items']:
+            if "customUrl" in item['snippet']:
+                if user.casefold()==item['snippet']["customUrl"].casefold():
+                    user = item['id']
+                    break
+
+        # Variable user now has a channel ID; prepare for classical route
         id_type = 'channel'
 
     id_type = 'id' if id_type == 'channel' else 'forUsername'

--- a/utils/render_feed.py
+++ b/utils/render_feed.py
@@ -17,7 +17,7 @@ def render_feed(playlist_data, channel_data, podcast_type):
     for item in videos_data['items']:
         # Reformat publication dates for RSS (RFC 2822)
         date_ISO = item['snippet']['publishedAt']
-        d = datetime.datetime.strptime(date_ISO, "%Y-%m-%dT%H:%M:%S.%fZ")
+        d = datetime.datetime.strptime(date_ISO, "%Y-%m-%dT%H:%M:%SZ")
         date_RFC = d.strftime('%a, %d %b %Y %H:%M:%S +0000')
         item['snippet']['publishedAt'] = date_RFC
         # Reformat file duration for iTunes

--- a/utils/youtube_api_call.py
+++ b/utils/youtube_api_call.py
@@ -14,6 +14,9 @@ def yt_api_call(path, part, id_type, id_value):
               'part': part,
               'maxResults': 10}
 
+    if id_type == 'q':
+        params['type'] = 'channel'
+
     data_url = (ENDPOINT + path + '?' + urlencode(params))
 
     r = requests.get(data_url)

--- a/views/channel.py
+++ b/views/channel.py
@@ -5,12 +5,14 @@ from flask import request
 from g import DOMAIN
 
 
-@app.route("/user/<user>", defaults={'id_type': 'user', 'format': 'video'})
-@app.route("/channel/<user>", defaults={'id_type': 'channel', 'format': 'video'})
-@app.route("/user/<user>/audio", defaults={'id_type': 'user', 'format': 'audio'})
+@app.route("/user/<user>",          defaults={'id_type': 'user',    'format': 'video'})
+@app.route("/channel/<user>",       defaults={'id_type': 'channel', 'format': 'video'})
+@app.route("/c/<user>",             defaults={'id_type': 'custom',  'format': 'video'})
+@app.route("/user/<user>/audio",    defaults={'id_type': 'user',    'format': 'audio'})
 @app.route("/channel/<user>/audio", defaults={'id_type': 'channel', 'format': 'audio'})
+@app.route("/c/<user>/audio",       defaults={'id_type': 'custom',  'format': 'audio'})
 def user(id_type, user, format):
-    '''Generate a feed for a channel'''
+    '''Generate a feed for a channel or user or custom URL'''
     channel_data = get_channel_data(id_type, user)
 
     try:

--- a/views/download.py
+++ b/views/download.py
@@ -1,7 +1,6 @@
 from flask import redirect
 from app import app
 
-#import youtube_dl
 import yt_dlp as youtube_dl
 
 ydl_opts_audio = {

--- a/views/download.py
+++ b/views/download.py
@@ -1,7 +1,8 @@
 from flask import redirect
 from app import app
 
-import youtube_dl
+#import youtube_dl
+import yt_dlp as youtube_dl
 
 ydl_opts_audio = {
     'verbose': False,


### PR DESCRIPTION
- Adds the `passenger_wsgi.py` to run on DreamHost out of the box
- Fix date time format string to newer tokens
- Replaces `podcast.becauseofprog.fr` to more generic `{{DOMAIN}}` in `feed.xml`, so it will work in other domains
- Support for YouTube customUrl as «youtube.com/c/{some_custom_url}»